### PR TITLE
Fix stripping URL scheme and domain from URL

### DIFF
--- a/src/model/ThunderstoreCombo.ts
+++ b/src/model/ThunderstoreCombo.ts
@@ -17,7 +17,7 @@ export default class ThunderstoreCombo {
 
     public static fromProtocol(protocol: string, modList: ThunderstoreMod[]): ThunderstoreCombo | R2Error {
         // Strip out protocol information
-        const reducedProtocol = protocol.replace(new RegExp("ror2mm://v1/install/([a-zA-Z0-9]+\.)?thunderstore\.io/"), '');
+        const reducedProtocol = protocol.replace(new RegExp("ror2mm://v1/install/([a-zA-Z0-9\-]+\.)?thunderstore\.io/"), '');
         const information = reducedProtocol.split('/');
         const packageName = `${information[0]}-${information[1]}`;
         const packageVersion = information[2];


### PR DESCRIPTION
Community identifiers, included in the mod installation URL, can contain hyphens. The regex used to parse the URLs didn't take that into account, which caused mod installation via URLs to fail if hyphens were included.