### PR TITLE
Add support for syncing mods via custom scheme link

### DIFF
--- a/src/model/game/Game.ts
+++ b/src/model/game/Game.ts
@@ -4,6 +4,9 @@ import { GameSelectionDisplayMode } from '../../model/game/GameSelectionDisplayM
 import { GameInstanceType } from '../../model/game/GameInstanceType';
 import { PackageLoader } from '../../model/installing/PackageLoader';
 
+const oldPackegeListRe = new RegExp(/https:\/\/([\w\-]+).thunderstore.io\/api\/v1\/package\//);
+const newPackegeListRe = new RegExp(/https:\/\/thunderstore.io\/c\/([\w\-]+)\/api\/v1\/package\//);
+
 export default class Game {
 
     private readonly _displayName: string;
@@ -72,6 +75,17 @@ export default class Game {
 
     get thunderstoreUrl(): string {
         return this._thunderstoreUrl;
+    }
+
+    /**
+     * Try to read TS community id from the URL.
+     *
+     * Uses RoR2 as the fallback, since it has special URLs.
+     */
+    get thunderstoreCommunity(): string {
+        let matches = this._thunderstoreUrl.match(oldPackegeListRe)?.[1];
+        matches = matches ?? this._thunderstoreUrl.match(newPackegeListRe)?.[1];
+        return matches ?? "risk-of-rain2"
     }
 
     get exclusionsUrl(): string {

--- a/src/utils/UriUtils.ts
+++ b/src/utils/UriUtils.ts
@@ -1,0 +1,51 @@
+export interface Ror2Uri {
+    scheme: "ror2mm";
+    version: string;
+    action: string;
+    parameters: string[];
+}
+
+/**
+ * Custom URI scheme for deep linking into the mod manager.
+ *
+ * Format: ror2mm://<version>/<action>/[{parameters}/...]
+ *
+ * Examples:
+ * ror2mm://v1/install/thunderstore.io/bbepis/BepInExPack/1.2.0/
+ * ror2mm://v1/sync/server/0181ccb5-f160-23e7-bb54-cfdf6d3af56c/
+ */
+const ror2UriRe = new RegExp(/ror2mm:\/\/(\w+)\/(\w+)\/?(.*\/?)/);
+
+export const URI_ACTION_INSTALL = "install";
+export const URI_ACTION_SYNC = "sync";
+
+const SUPPORTED: Record<string, string[]> = {
+    "v1": [URI_ACTION_INSTALL, URI_ACTION_SYNC],
+};
+
+
+/**
+ * Helper for parsing and validating custom scheme URIs.
+ *
+ * Deep linking to the mod manager is done via ror2mm:// scheme.
+ */
+export const parseCustomUri = (url: string): Ror2Uri|null => {
+    const matches = url.match(ror2UriRe);
+
+    if (!matches) {
+        return null;
+    }
+
+    const [, version, action, parameters] = matches;
+
+    if (!SUPPORTED[version]?.includes(action)) {
+        return null;
+    }
+
+    return {
+        scheme: "ror2mm",
+        version,
+        action,
+        parameters: parameters.split("/").filter(Boolean)
+    };
+}


### PR DESCRIPTION
This is a MVP implementation that leaves much to hope for.

Currently actions triggered by the links are defined on component-basis. This means use needs to have a correct page already open in the mod manager for the link to actually do what it's supposed to. Ideally link actions would be defined globally and would support moving to the correct page if necessary.

Both current implementations (installing a mod and syncing mods from a server listing) also require the mod manager to have the correct game and suitable mod profile selected for the actions to work. User isn't even notified about the issue: the links simply do nothing.

Current actions are also tightly coupled with the component they're defined in. This could perhaps be solved with a provider-based approach, which would also allow defining the actions centrally in one place, reducing duplication and avoiding conflicts.
actions inside vue component when shouldn't
provider based centralized approach

Error handling is currently quite non-existent.

Both links are currently initialized with old hookModInstallProtocol, which is now a misnomer. Renaming it would also require changes to non-Thunderstore Mod Manager parts, and was left out the scope of this commit.

Refs TS-682